### PR TITLE
add messaging for non-main branch without pr

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -22,12 +22,14 @@ jobs:
   command-tests-pr:
     docker:
       - image: cimg/base:stable
+    environment:
+      # TODO: pull requests are not propagated with triggered jobs
+      CIRCLE_PULL_REQUEST: https://circleci.com/gh/boostsecurityio/boostsec-scanner-circleci/392
     steps:
       - checkout
       - setup_remote_docker
       - boostsec/scan:
           api_enabled: false # TODO: temporarily disabled
-          additional_args: "--pull-request=1" # TODO -- PR number not preserved during dynamic config
           registry_module: scanners/boostsecurityio/native-scanner
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased - [Github](https://github.com/boostsecurityio/boostsec-scanner-circleci/compare/v4.0.0..HEAD)
+## Unreleased - [Github](https://github.com/boostsecurityio/boostsec-scanner-circleci/compare/v4.0.1..HEAD)
+
+## v4.0.1 - 2022-10-13 - [Github](https://github.com/boostsecurityio/boostsec-scanner-circleci/compare/v4.0.0...v4.0.1)
+
+- Output a message and exit for non-main prs when no pull-request
 
 ## v4.0.0 - 2022-10-05 - [Github](https://github.com/boostsecurityio/boostsec-scanner-circleci/compare/v3.0.0...v4.0.0)
 

--- a/src/scripts/scan.sh
+++ b/src/scripts/scan.sh
@@ -39,6 +39,11 @@ init.ci.config ()
 
   if [ "${CIRCLE_BRANCH:-}" != "${BOOST_GIT_MAIN_BRANCH}" ]; then
     export BOOST_GIT_BASE=${BOOST_GIT_MAIN_BRANCH}
+
+    if [ -z "${CIRCLE_PULL_REQUEST:-}" ]; then
+      log.info "non-main branch without a pull-request is not supported"
+      exit 0
+    fi
   fi
 }
 

--- a/src/tests/lib.circleci.bats
+++ b/src/tests/lib.circleci.bats
@@ -1,0 +1,52 @@
+setup ()
+{
+  bats_load_library "bats-assert"
+  bats_load_library "bats-file"
+  bats_load_library "bats-support"
+
+  PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
+  export BATS_ENABLED=true
+  export SCRIPT_PATH=${PROJECT_ROOT}/src/scripts
+
+  export CIRCLE_BRANCH="main"
+  export BOOST_GIT_MAIN_BRANCH="main" # do not attempt git ops
+  export BOOST_API_TOKEN_VAR=BOOST_API_TOKEN_VALUE
+  export BOOST_API_TOKEN_VALUE=123456
+
+  # shellcheck disable=SC1091
+  source "${SCRIPT_PATH}/scan.sh"
+}
+
+teardown ()
+{
+  :
+}
+
+@test "init.ci.config BOOST_API_TOKEN defined" {
+  export BOOST_API_TOKEN
+  export BOOST_API_TOKEN_VAR=BOOST_API_TOKEN_DATA
+  export BOOST_API_TOKEN_DATA=123456
+  init.config
+
+  assert_equal "${BOOST_API_TOKEN}" "${BOOST_API_TOKEN_DATA}"
+}
+
+@test "init.ci.config BOOST_GIT_BASE defined" {
+  export BOOST_GIT_BASE=""
+  export BOOST_GIT_MAIN_BRANCH="test"
+  export CIRCLE_BRANCH=not-main
+  export CIRCLE_PULL_REQUEST=http://url/123
+  init.config
+
+  assert_equal "${BOOST_GIT_BASE}" "${BOOST_GIT_MAIN_BRANCH}"
+}
+
+@test "init.ci.config CIRCLE_PULL_REQUEST required" {
+  export CIRCLE_BRANCH="potato"
+  run init.config
+
+  assert_output --partial "non-main branch without a pull-request is not supported"
+}
+
+# vim: set ft=bash ts=2 sw=2 et :

--- a/src/tests/lib.scan.bats
+++ b/src/tests/lib.scan.bats
@@ -9,8 +9,8 @@ setup ()
   export BATS_ENABLED=true
   export SCRIPT_PATH=${PROJECT_ROOT}/src/scripts
 
+  export CIRCLE_BRANCH="main"
   export BOOST_GIT_MAIN_BRANCH="main" # do not attempt git ops
-
   export BOOST_API_TOKEN_VAR=BOOST_API_TOKEN_VALUE
   export BOOST_API_TOKEN_VALUE=123456
 
@@ -115,6 +115,7 @@ teardown ()
 }
 
 @test "init.config BOOST_GIT_MAIN_BRANCH defined" {
+  export CIRCLE_BRANCH="master"
   export BOOST_GIT_MAIN_BRANCH=""
 
   pushd ${BATS_TEST_TMPDIR} > /dev/null
@@ -131,24 +132,6 @@ teardown ()
   init.config
 
   assert_equal "${BOOST_GIT_MAIN_BRANCH}" "main"
-}
-
-@test "init.config BOOST_API_TOKEN defined" {
-  export BOOST_API_TOKEN
-  export BOOST_API_TOKEN_VAR=BOOST_API_TOKEN_DATA
-  export BOOST_API_TOKEN_DATA=123456
-  init.config
-
-  assert_equal "${BOOST_API_TOKEN}" "${BOOST_API_TOKEN_DATA}"
-}
-
-@test "init.config BOOST_GIT_BASE defined" {
-  export BOOST_GIT_BASE=""
-  export BOOST_GIT_MAIN_BRANCH="test"
-  export CIRCLE_BRANCH=not-main
-  init.config
-
-  assert_equal "${BOOST_GIT_BASE}" "${BOOST_GIT_MAIN_BRANCH}"
 }
 
 @test "init.cli creates tmpdir" {


### PR DESCRIPTION
the api currently requires that a pull-request be present when scanning a non-main branch
this poses a problem since circleci jobs will often trigger before the PR has been opened.
to work around this, we temporarily add an info message and noop