### PR TITLE
handle undefined api token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased - [Github](https://github.com/boostsecurityio/boostsec-scanner-circleci/compare/v4.0.1..HEAD)
 
+## v4.0.2 - 2022-10-13 - [Github](https://github.com/boostsecurityio/boostsec-scanner-circleci/compare/v4.0.1...v4.0.2)
+
+- Correctly handle the case where the API token variable is unset
+
 ## v4.0.1 - 2022-10-13 - [Github](https://github.com/boostsecurityio/boostsec-scanner-circleci/compare/v4.0.0...v4.0.1)
 
 - Output a message and exit for non-main prs when no pull-request

--- a/src/scripts/scan.sh
+++ b/src/scripts/scan.sh
@@ -35,7 +35,7 @@ init.config ()
 
 init.ci.config ()
 {
-  export BOOST_API_TOKEN=${!BOOST_API_TOKEN_VAR}
+  export BOOST_API_TOKEN=${!BOOST_API_TOKEN_VAR:-}
 
   if [ "${CIRCLE_BRANCH:-}" != "${BOOST_GIT_MAIN_BRANCH}" ]; then
     export BOOST_GIT_BASE=${BOOST_GIT_MAIN_BRANCH}

--- a/src/tests/lib.circleci.bats
+++ b/src/tests/lib.circleci.bats
@@ -32,6 +32,14 @@ teardown ()
   assert_equal "${BOOST_API_TOKEN}" "${BOOST_API_TOKEN_DATA}"
 }
 
+@test "init.ci.config BOOST_API_TOKEN undefined" {
+  export BOOST_API_TOKEN
+  export BOOST_API_TOKEN_VAR=BOOST_API_TOKEN_DATA
+  init.config
+
+  assert_equal "${BOOST_API_TOKEN}" ""
+}
+
 @test "init.ci.config BOOST_GIT_BASE defined" {
   export BOOST_GIT_BASE=""
   export BOOST_GIT_MAIN_BRANCH="test"


### PR DESCRIPTION
resolve an error where the orb would crash when the api token variable was not defined
now, the CLI will execute as expected and return an error if ti did indeed require the token
this should resolve running the command with api_enabled: false 